### PR TITLE
Test fixes for non-US locales

### DIFF
--- a/tests/X12.Tests.Unit/Creation/Invoice810CreationTester.cs
+++ b/tests/X12.Tests.Unit/Creation/Invoice810CreationTester.cs
@@ -37,7 +37,7 @@ IEA*1*000000035~";
         [Test]
         public void Create810_4010Version()
         {
-            var message = new Interchange(Convert.ToDateTime("1/4/99 15:32"), 35, false, '~','*','>')
+            var message = new Interchange(new DateTime(1999, 1, 4, 15, 32, 0), 35, false, '~','*','>')
             {
                 SecurityInfoQualifier = "00",
                 InterchangeSenderIdQualifier = "30",
@@ -46,7 +46,7 @@ IEA*1*000000035~";
                 InterchangeReceiverId = "0069088189999"
             };
 
-            var fg = message.AddFunctionGroup("IN", Convert.ToDateTime("1/4/1999 15:32"), 1);
+            var fg = message.AddFunctionGroup("IN", new DateTime(1999, 1, 4, 15, 32, 0), 1);
             fg.ApplicationSendersCode = "943274043TO";
             fg.ApplicationReceiversCode = "0069088189999";
             fg.ResponsibleAgencyCode = "X";
@@ -55,7 +55,7 @@ IEA*1*000000035~";
             var trans = fg.AddTransaction("810", "0001");
 
             var big = trans.AddSegment(new TypedSegmentBIG());
-            big.BIG01_InvoiceDate = Convert.ToDateTime("10/14/1998");
+            big.BIG01_InvoiceDate = new DateTime(1998, 10, 14);
             big.BIG02_InvoiceNumber = "3662";
             big.BIG07_TransactionTypeCode = "N6";
 
@@ -95,7 +95,7 @@ IEA*1*000000035~";
 
             var itd = trans.AddSegment(new TypedSegmentITD());
             itd.ITD01_TermsTypeCode = "03";
-            itd.ITD06_TermsNetDueDate = Convert.ToDateTime("10/20/1998");
+            itd.ITD06_TermsNetDueDate = new DateTime(1998, 10, 20);
 
             var it1 = trans.AddLoop(new TypedLoopIT1());
             it1.IT101_AssignedIdentification = "1";

--- a/tests/X12.Tests.Unit/Creation/ProfessionalClaimCreationTester.cs
+++ b/tests/X12.Tests.Unit/Creation/ProfessionalClaimCreationTester.cs
@@ -17,7 +17,7 @@
         [Test]
         public void Create837_5010Version()
         {
-            var message = new Interchange(Convert.ToDateTime("01/01/03"), 000905, false)
+            var message = new Interchange(new DateTime(2003, 1, 1), 000905, false)
                               {
                                   InterchangeSenderIdQualifier = "ZZ",
                                   InterchangeSenderId = "SUBMITTERS.ID",
@@ -33,7 +33,7 @@
             var group = message.AddFunctionGroup("HC", DateTime.Now, 1, "005010X222");
             group.ApplicationSendersCode = "SENDER CODE";
             group.ApplicationReceiversCode = "RECEIVER CODE";
-            group.Date = Convert.ToDateTime("12/31/1999");
+            group.Date = new DateTime(1999, 12, 31);
             group.ControlNumber = 1;
             group.SetElement(5, "0802");
 
@@ -123,7 +123,7 @@
 
             var subscriber_DMGSegment = subscriberName2010BALoop.AddSegment(new TypedSegmentDMG());
             subscriber_DMGSegment.DMG01_DateTimePeriodFormatQualifier = "D8";
-            subscriber_DMGSegment.DMG02_DateOfBirth = DateTime.Parse("5/1/1943");
+            subscriber_DMGSegment.DMG02_DateOfBirth = new DateTime(1943, 5, 1);
             subscriber_DMGSegment.DMG03_Gender = Gender.Female;
 
             var subscriberName2010BALoop2 = subscriber2000BHLoop.AddLoop(new TypedLoopNM1("PR"));
@@ -156,7 +156,7 @@
 
             var HL3NM1_DMG_Segment = HL3NM1Segment.AddSegment(new TypedSegmentDMG());
             HL3NM1_DMG_Segment.DMG01_DateTimePeriodFormatQualifier = "D8";
-            HL3NM1_DMG_Segment.DMG02_DateOfBirth = Convert.ToDateTime("5/1/1973");
+            HL3NM1_DMG_Segment.DMG02_DateOfBirth = new DateTime(1973, 5, 1);
             HL3NM1_DMG_Segment.DMG03_Gender = Gender.Male;
 
             var claim2300Loop = HL3Loop.AddLoop(new TypedLoopCLM());

--- a/tests/X12.Tests.Unit/DocumentationCodeSamples/X12InterchangeModel/ReadingAnExistingX12File.cs
+++ b/tests/X12.Tests.Unit/DocumentationCodeSamples/X12InterchangeModel/ReadingAnExistingX12File.cs
@@ -1,4 +1,6 @@
-﻿namespace X12.Tests.Unit.DocumentationCodeSamples.X12InterchangeModel
+﻿using System.Globalization;
+
+namespace X12.Tests.Unit.DocumentationCodeSamples.X12InterchangeModel
 {
     using System;
     using System.Diagnostics;
@@ -218,12 +220,12 @@ IEA*1*000000031~
             member.NM109_IdCode = "11122333301";
 
             TypedSegmentDMG birthday = member.AddSegment(new TypedSegmentDMG());
-            birthday.DMG02_DateOfBirth = DateTime.Parse("05/19/1943");
+            birthday.DMG02_DateOfBirth = new DateTime(1943, 5, 19);
 
             TypedSegmentDTP subscribeDate = member.AddSegment(new TypedSegmentDTP());
             subscribeDate.DTP01_DateTimeQualifier = DTPQualifier.Plan;
             subscribeDate.DTP02_DateTimePeriodFormatQualifier = DTPFormatQualifier.CCYYMMDD;
-            subscribeDate.DTP03_Date = new DateTimePeriod(DateTime.Parse("05/01/2006"));
+            subscribeDate.DTP03_Date = new DateTimePeriod(new DateTime(2006, 5, 1));
             
             member.AddLoop("EQ*30");
 


### PR DESCRIPTION
Removes dependency on US-centric date string processing, to fix a few tests