### PR TITLE
X12StreamReader Ignores Transaction Trailing Segment

### DIFF
--- a/src/X12.Hipaa.ClaimParser/Program.cs
+++ b/src/X12.Hipaa.ClaimParser/Program.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Configuration;
     using System.IO;
+    using System.Linq;
     using System.Xml;
 
     using Fonet;

--- a/src/X12.Parsing/X12StreamReader.cs
+++ b/src/X12.Parsing/X12StreamReader.cs
@@ -170,10 +170,12 @@
         {
             var segments = new StringBuilder();
 
-            string segmentString = this.ReadNextSegment();
-            string segmentId = this.ReadSegmentId(segmentString);
+            string segmentString;
+            string segmentId;
             do
             {
+                segmentString = this.ReadNextSegment();
+                segmentId = this.ReadSegmentId(segmentString);
                 switch (segmentId)
                 {
                     case "ISA":
@@ -195,9 +197,6 @@
                         segments.Append(this.Delimiters.SegmentTerminator);
                         break;
                 }
-
-                segmentString = this.ReadNextSegment();
-                segmentId = this.ReadSegmentId(segmentString);
             }
             while (!string.IsNullOrEmpty(segmentString) && segmentId != "SE");
 


### PR DESCRIPTION
Fix trailing transaction segment being ignored by the X12StreamReader.

fixes #19 